### PR TITLE
Bump mongoose in the npm_and_yarn group across 1 directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"humanize-duration": "^3.27.3",
 		"lodash": "^4.17.21",
 		"moment-timezone": "^0.5.37",
-		"mongoose": "^6.5.4",
+		"mongoose": "^8.8.3",
 		"ms": "^2.1.3",
 		"node-fetch": "^2.6.1",
 		"set-interval": "^2.1.3",


### PR DESCRIPTION
Bumps the npm_and_yarn group with 1 update in the / directory: [mongoose](https://github.com/Automattic/mongoose).


Updates `mongoose` from 6.13.5 to 8.8.3
- [Release notes](https://github.com/Automattic/mongoose/releases)
- [Changelog](https://github.com/Automattic/mongoose/blob/master/CHANGELOG.md)
- [Commits](https://github.com/Automattic/mongoose/compare/6.13.5...8.8.3)

---
updated-dependencies:
- dependency-name: mongoose dependency-type: direct:production dependency-group: npm_and_yarn ...